### PR TITLE
Enhance the compatibility of unit testing

### DIFF
--- a/src/test/java/de/marhali/json5/TestJson5.java
+++ b/src/test/java/de/marhali/json5/TestJson5.java
@@ -45,7 +45,10 @@ public class TestJson5 {
                 buf.write((byte) result);
             }
 
-            return buf.toString(StandardCharsets.UTF_8);
+             return Optional.ofNullable(buf.toString(StandardCharsets.UTF_8))
+                .map(s->s.replace("\r\n","\n"))
+                .map(s->s.replace("\r","\n"))
+                .orElse(null);
         }
     }
 


### PR DESCRIPTION
Below UT will fail when it run on Windows:
```java
 @Test
    void ioArrayFile() throws IOException {
        try(InputStream stream = getTestResource("test.array.json5")) {
            Json5Element element = json5.parse(stream);
            assertTrue(element.isJson5Array());
            assertEquals(getTestResourceContent("expect.array.json5"), json5.serialize(element));
        }
    }

    @Test
    void ioObjectFile() throws IOException {
        try(InputStream stream = getTestResource("test.object.json5")) {
            Json5Element element = json5.parse(stream);
            assertTrue(element.isJson5Object());
            assertEquals(getTestResourceContent("expect.object.json5"), json5.serialize(element));
        }
    }
```
Because `getTestResourceContent` 's return str cotanis sys based line sep but `json5.serialize(element)` always use `\n` as line sep